### PR TITLE
Fix parse error in SHA256.cry

### DIFF
--- a/examples/hmac/SHA256.cry
+++ b/examples/hmac/SHA256.cry
@@ -162,7 +162,7 @@ SHA256Update sinit bs = ss!0
   where ss = [sinit] # [ SHA256Update1 s b | s <- ss | b <- bs ]
 
 update : {a, b, c} (fin c, c >= width (2 ^^ c - 1)) => [b]a -> [c] -> a -> [min b (2 ^^ c)]a
-update a i x = [ if j == i then x else e | e <- a | j <- [0 ..] ]
+update a i x = take [ if j == i then x else e | e <- a | j <- [0 ...] ]
 
 // Add padding and size and process the final block.
 SHA256Final : SHA256State -> [256]


### PR DESCRIPTION
Hi there,

Currently, when trying to test the HMAC maintenance exercises, I get a parse error when Cryptol attempts to import `SHA256.cry`:

```
Parse error at SHA256.cry:165:64,
  unexpected: ]
```

This commit fixes this error. I'm new to Cryptol, so let me know if any changes need to be made. Thanks!